### PR TITLE
Add testAll function to generate tests from a list of inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,8 @@ npm install
 ```
 
 Then build and run tests with `npm test`, start watchers for `bsb`and `jest` with `npm run watch:bsb` and `npm run watch:jest` respectively. Install `screen` to be able to use `npm run watch:screen` to run both watchers in a single terminal window.
+
+## Changes
+
+### Next
+* Added `testAll`, `Only.testAll`, `Skip.testAll` that generates tests from a list of inputs

--- a/__tests__/globals_test.ml
+++ b/__tests__/globals_test.ml
@@ -2,26 +2,38 @@ open Jest
 open Expect
 
 let _ =
-  test "test" (fun _ -> expect (1 + 2) |> toBe 3);
+  test "test" (fun _ ->
+    expect (1 + 2) |> toBe 3);
   (*
-  test "test - expect fail" (fun _ -> expect (1 + 2) |> toBe 4);
+  test "test - expect fail" (fun _ ->
+    expect (1 + 2) |> toBe 4);
   *)
   
-  testAsync "testAsync" (fun done_ -> done_ (expect (1 + 2) |> toBe 3));
+  testAsync "testAsync" (fun done_ ->
+    done_ (expect (1 + 2) |> toBe 3));
   (*
   testAsync "testAsync - no done" (fun _ -> ());
   *)
   (*
-  testAsync "testAsync - expect fail" (fun done_ -> done_ (expect (1 + 2) |> toBe 4));
+  testAsync "testAsync - expect fail" (fun done_ ->
+    done_ (expect (1 + 2) |> toBe 4));
   *)
   
-  testPromise "testPromise" (fun _ -> Js.Promise.resolve (expect (1 + 2) |> toBe 3));
+  testPromise "testPromise" (fun _ ->
+    Js.Promise.resolve (expect (1 + 2) |> toBe 3));
   (*
-  testPromise "testPromise - reject" (fun _ -> Promise.reject ());
+  testPromise "testPromise - reject" (fun _ ->
+    Promise.reject ());
   *)
   (*
-  testPromise "testPromise - expect fail" (fun _ -> Promise.resolve (expect (1 + 2) |> toBe 4));
+  testPromise "testPromise - expect fail" (fun _ ->
+    Promise.resolve (expect (1 + 2) |> toBe 4));
   *)
+
+  testAll "testAll" ["foo"; "bar"; "baz"] (fun input ->
+    expect (Js.String.length input) |> toEqual 3);
+  testAll "testAll - tuples" [("foo", 3); ("barbaz", 6); ("bananas!", 8)] (fun (input, output) ->
+    expect (Js.String.length input) |> toEqual output);
   
   describe "describe" (fun _ ->
     test "some aspect" (fun _ -> expect (1 + 2) |> toBe 3)
@@ -68,9 +80,16 @@ let _ =
     (*
     Only.test "Only.test" (fun _ -> (expect (1 + 2) |> toBe 3));
 
-    Only.testAsync "Only.testAsync" (fun done_ -> done_ (expect (1 + 2) |> toBe 3));
+    Only.testAsync "Only.testAsync" (fun done_ ->
+      done_ (expect (1 + 2) |> toBe 3));
 
-    Only.testPromise "Only.testPromise" (fun _ -> Promise.resolve (expect (1 + 2) |> toBe 3));
+    Only.testPromise "Only.testPromise" (fun _ ->
+      Promise.resolve (expect (1 + 2) |> toBe 3));
+
+    Only.testAll "testAll" ["foo"; "bar"; "baz"] (fun input ->
+      expect (Js.String.length input) |> toEqual 3);
+    Only.testAll "testAll - tuples" [("foo", 3); ("barbaz", 6); ("bananas!", 8)] (fun (input, output) ->
+      expect (Js.String.length input) |> toEqual output);
 
     Only.describe "Only.describe" (fun _ ->
       test "some aspect" (fun _ -> (expect (1 + 2)) |> toBe 3)
@@ -87,6 +106,11 @@ let _ =
 
     Skip.testPromise "Skip.testPromise" (fun _ ->
       Js.Promise.resolve (expect (1 + 2) |> toBe 3));
+
+    Skip.testAll "testAll" ["foo"; "bar"; "baz"] (fun input ->
+      expect (Js.String.length input) |> toEqual 3);
+    Skip.testAll "testAll - tuples" [("foo", 3); ("barbaz", 6); ("bananas!", 8)] (fun (input, output) ->
+      expect (Js.String.length input) |> toEqual output);
 
     Skip.describe "Skip.describe" (fun _ ->
       test "some aspect" (fun _ -> expect (1 + 2) |> toBe 3)

--- a/lib/js/__tests__/expect_test.js
+++ b/lib/js/__tests__/expect_test.js
@@ -7,64 +7,64 @@ var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exception
 
 describe("Expect", (function () {
         Jest.test("toBe", (function () {
-                return Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3));
+                return Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3));
               }));
         Jest.test("toBeCloseTo", (function () {
-                return Curry._2(Jest.Expect[/* toBeCloseTo */3], 3, Curry._1(Jest.Expect[/* expect */0], 1 + 2));
+                return Jest.Expect[/* toBeCloseTo */3](3)(Jest.Expect[/* expect */0](1 + 2));
               }));
         Jest.test("toBeSoCloseTo", (function () {
-                return Curry._3(Jest.Expect[/* toBeSoCloseTo */4], 3, 9, Curry._1(Jest.Expect[/* expect */0], 1 + 2));
+                return Jest.Expect[/* toBeSoCloseTo */4](3, 9)(Jest.Expect[/* expect */0](1 + 2));
               }));
         Jest.test("toBeGreaterThan", (function () {
-                return Curry._2(Jest.Expect[/* toBeGreaterThan */5], 3, Curry._1(Jest.Expect[/* expect */0], 4));
+                return Jest.Expect[/* toBeGreaterThan */5](3)(Jest.Expect[/* expect */0](4));
               }));
         Jest.test("toBeGreaterThanOrEqual", (function () {
-                return Curry._2(Jest.Expect[/* toBeGreaterThanOrEqual */6], 4, Curry._1(Jest.Expect[/* expect */0], 4));
+                return Jest.Expect[/* toBeGreaterThanOrEqual */6](4)(Jest.Expect[/* expect */0](4));
               }));
         Jest.test("toBeLessThan", (function () {
-                return Curry._2(Jest.Expect[/* toBeLessThan */7], 5, Curry._1(Jest.Expect[/* expect */0], 4));
+                return Jest.Expect[/* toBeLessThan */7](5)(Jest.Expect[/* expect */0](4));
               }));
         Jest.test("toBeLessThanOrEqual", (function () {
-                return Curry._2(Jest.Expect[/* toBeLessThanOrEqual */8], 4, Curry._1(Jest.Expect[/* expect */0], 4));
+                return Jest.Expect[/* toBeLessThanOrEqual */8](4)(Jest.Expect[/* expect */0](4));
               }));
         Jest.test("toBeSuperSetOf", (function () {
-                return Curry._2(Jest.Expect[/* toBeSupersetOf */9], /* array */[
-                            "a",
-                            "c"
-                          ], Curry._1(Jest.Expect[/* expect */0], /* array */[
+                return Jest.Expect[/* toBeSupersetOf */9](/* array */[
+                              "a",
+                              "c"
+                            ])(Jest.Expect[/* expect */0](/* array */[
                                 "a",
                                 "b",
                                 "c"
                               ]));
               }));
         Jest.test("toContain", (function () {
-                return Curry._2(Jest.Expect[/* toContain */10], "b", Curry._1(Jest.Expect[/* expect */0], /* array */[
+                return Jest.Expect[/* toContain */10]("b")(Jest.Expect[/* expect */0](/* array */[
                                 "a",
                                 "b",
                                 "c"
                               ]));
               }));
         Jest.test("toContainString", (function () {
-                return Curry._2(Jest.Expect[/* toContainString */11], "nana", Curry._1(Jest.Expect[/* expect */0], "banana"));
+                return Jest.Expect[/* toContainString */11]("nana")(Jest.Expect[/* expect */0]("banana"));
               }));
         Jest.test("toHaveLength", (function () {
-                return Curry._2(Jest.Expect[/* toHaveLength */13], 3, Curry._1(Jest.Expect[/* expect */0], /* array */[
+                return Jest.Expect[/* toHaveLength */13](3)(Jest.Expect[/* expect */0](/* array */[
                                 "a",
                                 "b",
                                 "c"
                               ]));
               }));
         Jest.test("toEqual", (function () {
-                return Curry._2(Jest.Expect[/* toEqual */12], 3, Curry._1(Jest.Expect[/* expect */0], 3));
+                return Jest.Expect[/* toEqual */12](3)(Jest.Expect[/* expect */0](3));
               }));
         Jest.test("toMatch", (function () {
-                return Curry._2(Jest.Expect[/* toMatch */14], "nana", Curry._1(Jest.Expect[/* expect */0], "banana"));
+                return Jest.Expect[/* toMatch */14]("nana")(Jest.Expect[/* expect */0]("banana"));
               }));
         Jest.test("toMatchRe", (function () {
-                return Curry._2(Jest.Expect[/* toMatchRe */15], (/ana/), Curry._1(Jest.Expect[/* expect */0], "banana"));
+                return Jest.Expect[/* toMatchRe */15]((/ana/))(Jest.Expect[/* expect */0]("banana"));
               }));
         Jest.test("toThrow", (function () {
-                return Curry._1(Jest.Expect[/* toThrow */18], Curry._1(Jest.Expect[/* expect */0], (function () {
+                return Jest.Expect[/* toThrow */18](Jest.Expect[/* expect */0]((function () {
                                   throw [
                                         Caml_builtin_exceptions.assert_failure,
                                         [
@@ -76,12 +76,12 @@ describe("Expect", (function () {
                                 })));
               }));
         test.skip("toThrow - no throw - should compile, but fail test", (function () {
-                return Curry._1(Jest.Expect[/* toThrow */18], Curry._1(Jest.Expect[/* expect */0], (function () {
+                return Jest.Expect[/* toThrow */18](Jest.Expect[/* expect */0]((function () {
                                   return 2;
                                 })));
               }));
         Jest.test("toThrowMessage", (function () {
-                return Curry._2(Jest.Expect[/* toThrowMessage */20], "Invalid_argument,-3,foo", Curry._1(Jest.Expect[/* expect */0], (function () {
+                return Jest.Expect[/* toThrowMessage */20]("Invalid_argument,-3,foo", Jest.Expect[/* expect */0]((function () {
                                   throw [
                                         Caml_builtin_exceptions.invalid_argument,
                                         "foo"
@@ -89,7 +89,7 @@ describe("Expect", (function () {
                                 })));
               }));
         Jest.test("toThrowMessageRe", (function () {
-                return Curry._2(Jest.Expect[/* toThrowMessageRe */21], (/Assert_failure/), Curry._1(Jest.Expect[/* expect */0], (function () {
+                return Jest.Expect[/* toThrowMessageRe */21]((/Assert_failure/), Jest.Expect[/* expect */0]((function () {
                                   throw [
                                         Caml_builtin_exceptions.assert_failure,
                                         [
@@ -101,10 +101,10 @@ describe("Expect", (function () {
                                 })));
               }));
         Jest.test("not_ |> toBe", (function () {
-                return Curry._2(Jest.Expect[/* toBe */2], 4, Curry._1(Jest.Expect[/* not_ */22], Curry._1(Jest.Expect[/* expect */0], 3)));
+                return Jest.Expect[/* toBe */2](4)(Jest.Expect[/* not_ */22](Jest.Expect[/* expect */0](3)));
               }));
         return Jest.test("expectFn", (function () {
-                      return Curry._2(Jest.Expect[/* toThrowMessage */20], "Invalid_argument,-3,foo", Curry._2(Jest.Expect[/* expectFn */1], (function (prim) {
+                      return Jest.Expect[/* toThrowMessage */20]("Invalid_argument,-3,foo", Jest.Expect[/* expectFn */1]((function (prim) {
                                         throw prim;
                                       }), [
                                       Caml_builtin_exceptions.invalid_argument,
@@ -115,125 +115,125 @@ describe("Expect", (function () {
 
 describe("Expect.Operators", (function () {
         Jest.test("==", (function () {
-                return Curry._2(Jest.Expect[/* Operators */23][/* == */0], Curry._1(Jest.Expect[/* expect */0], 3), 3);
+                return Curry._2(Jest.Expect[/* Operators */23][/* == */0], Jest.Expect[/* expect */0](3), 3);
               }));
         Jest.test(">", (function () {
-                return Curry._2(Jest.Expect[/* Operators */23][/* > */1], Curry._1(Jest.Expect[/* expect */0], 4), 3);
+                return Curry._2(Jest.Expect[/* Operators */23][/* > */1], Jest.Expect[/* expect */0](4), 3);
               }));
         Jest.test(">=", (function () {
-                return Curry._2(Jest.Expect[/* Operators */23][/* >= */2], Curry._1(Jest.Expect[/* expect */0], 4), 4);
+                return Curry._2(Jest.Expect[/* Operators */23][/* >= */2], Jest.Expect[/* expect */0](4), 4);
               }));
         Jest.test("<", (function () {
-                return Curry._2(Jest.Expect[/* Operators */23][/* < */3], Curry._1(Jest.Expect[/* expect */0], 4), 5);
+                return Curry._2(Jest.Expect[/* Operators */23][/* < */3], Jest.Expect[/* expect */0](4), 5);
               }));
         Jest.test("<=", (function () {
-                return Curry._2(Jest.Expect[/* Operators */23][/* <= */4], Curry._1(Jest.Expect[/* expect */0], 4), 4);
+                return Curry._2(Jest.Expect[/* Operators */23][/* <= */4], Jest.Expect[/* expect */0](4), 4);
               }));
         Jest.test("=", (function () {
-                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Curry._1(Jest.Expect[/* expect */0], 3), 3);
+                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Jest.Expect[/* expect */0](3), 3);
               }));
         Jest.test("<>", (function () {
-                return Curry._2(Jest.Expect[/* Operators */23][/* <> */6], Curry._1(Jest.Expect[/* expect */0], 3), 4);
+                return Curry._2(Jest.Expect[/* Operators */23][/* <> */6], Jest.Expect[/* expect */0](3), 4);
               }));
         return Jest.test("!=", (function () {
-                      return Curry._2(Jest.Expect[/* Operators */23][/* != */7], Curry._1(Jest.Expect[/* expect */0], 3), 4);
+                      return Curry._2(Jest.Expect[/* Operators */23][/* != */7], Jest.Expect[/* expect */0](3), 4);
                     }));
       }));
 
 describe("ExpectJs", (function () {
         Jest.test("toBe", (function () {
-                return Curry._2(Jest.ExpectJs[/* toBe */2], 3, Curry._1(Jest.ExpectJs[/* expect */0], 3));
+                return Jest.ExpectJs[/* toBe */2](3)(Jest.ExpectJs[/* expect */0](3));
               }));
         Jest.test("toBeCloseTo", (function () {
-                return Curry._2(Jest.ExpectJs[/* toBeCloseTo */3], 3, Curry._1(Jest.ExpectJs[/* expect */0], 1 + 2));
+                return Jest.ExpectJs[/* toBeCloseTo */3](3)(Jest.ExpectJs[/* expect */0](1 + 2));
               }));
         Jest.test("toBeSoCloseTo", (function () {
-                return Curry._3(Jest.ExpectJs[/* toBeSoCloseTo */4], 3, 9, Curry._1(Jest.ExpectJs[/* expect */0], 1 + 2));
+                return Jest.ExpectJs[/* toBeSoCloseTo */4](3, 9)(Jest.ExpectJs[/* expect */0](1 + 2));
               }));
         Jest.test("toBeDefined", (function () {
-                return Curry._1(Jest.ExpectJs[/* toBeDefined */24], Curry._1(Jest.ExpectJs[/* expect */0], 3));
+                return Jest.ExpectJs[/* toBeDefined */24](Jest.ExpectJs[/* expect */0](3));
               }));
         Jest.test("toBeFalsy", (function () {
-                return Curry._1(Jest.ExpectJs[/* toBeFalsy */25], Curry._1(Jest.ExpectJs[/* expect */0], Pervasives.nan));
+                return Jest.ExpectJs[/* toBeFalsy */25](Jest.ExpectJs[/* expect */0](Pervasives.nan));
               }));
         Jest.test("toBeGreaterThan", (function () {
-                return Curry._2(Jest.ExpectJs[/* toBeGreaterThan */5], 3, Curry._1(Jest.ExpectJs[/* expect */0], 4));
+                return Jest.ExpectJs[/* toBeGreaterThan */5](3)(Jest.ExpectJs[/* expect */0](4));
               }));
         Jest.test("toBeGreaterThanOrEqual", (function () {
-                return Curry._2(Jest.ExpectJs[/* toBeGreaterThanOrEqual */6], 4, Curry._1(Jest.ExpectJs[/* expect */0], 4));
+                return Jest.ExpectJs[/* toBeGreaterThanOrEqual */6](4)(Jest.ExpectJs[/* expect */0](4));
               }));
         Jest.test("toBeLessThan", (function () {
-                return Curry._2(Jest.ExpectJs[/* toBeLessThan */7], 5, Curry._1(Jest.ExpectJs[/* expect */0], 4));
+                return Jest.ExpectJs[/* toBeLessThan */7](5)(Jest.ExpectJs[/* expect */0](4));
               }));
         Jest.test("toBeLessThanOrEqual", (function () {
-                return Curry._2(Jest.ExpectJs[/* toBeLessThanOrEqual */8], 4, Curry._1(Jest.ExpectJs[/* expect */0], 4));
+                return Jest.ExpectJs[/* toBeLessThanOrEqual */8](4)(Jest.ExpectJs[/* expect */0](4));
               }));
         Jest.test("toBeNull", (function () {
-                return Curry._1(Jest.ExpectJs[/* toBeFalsy */25], Curry._1(Jest.ExpectJs[/* expect */0], Pervasives.nan));
+                return Jest.ExpectJs[/* toBeFalsy */25](Jest.ExpectJs[/* expect */0](Pervasives.nan));
               }));
         Jest.test("toBeSuperSetOf", (function () {
-                return Curry._2(Jest.ExpectJs[/* toBeSupersetOf */9], /* array */[
-                            "a",
-                            "c"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* array */[
+                return Jest.ExpectJs[/* toBeSupersetOf */9](/* array */[
+                              "a",
+                              "c"
+                            ])(Jest.ExpectJs[/* expect */0](/* array */[
                                 "a",
                                 "b",
                                 "c"
                               ]));
               }));
         Jest.test("toBeTruthy", (function () {
-                return Curry._1(Jest.ExpectJs[/* toBeTruthy */27], Curry._1(Jest.ExpectJs[/* expect */0], /* array */[]));
+                return Jest.ExpectJs[/* toBeTruthy */27](Jest.ExpectJs[/* expect */0](/* array */[]));
               }));
         Jest.test("toBeUndefined", (function () {
-                return Curry._1(Jest.ExpectJs[/* toBeUndefined */28], Curry._1(Jest.ExpectJs[/* expect */0], undefined));
+                return Jest.ExpectJs[/* toBeUndefined */28](Jest.ExpectJs[/* expect */0](undefined));
               }));
         Jest.test("toContain", (function () {
-                return Curry._2(Jest.ExpectJs[/* toContain */10], "b", Curry._1(Jest.ExpectJs[/* expect */0], /* array */[
+                return Jest.ExpectJs[/* toContain */10]("b")(Jest.ExpectJs[/* expect */0](/* array */[
                                 "a",
                                 "b",
                                 "c"
                               ]));
               }));
         Jest.test("toContainString", (function () {
-                return Curry._2(Jest.ExpectJs[/* toContainString */11], "nana", Curry._1(Jest.ExpectJs[/* expect */0], "banana"));
+                return Jest.ExpectJs[/* toContainString */11]("nana")(Jest.ExpectJs[/* expect */0]("banana"));
               }));
         Jest.test("toContainProperties", (function () {
-                return Curry._2(Jest.ExpectJs[/* toContainProperties */29], /* array */[
-                            "foo",
-                            "bar"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], {
+                return Jest.ExpectJs[/* toContainProperties */29](/* array */[
+                              "foo",
+                              "bar"
+                            ])(Jest.ExpectJs[/* expect */0]({
                                 foo: 0,
                                 bar: /* true */1
                               }));
               }));
         Jest.test("toHaveLength", (function () {
-                return Curry._2(Jest.ExpectJs[/* toHaveLength */13], 3, Curry._1(Jest.ExpectJs[/* expect */0], /* array */[
+                return Jest.ExpectJs[/* toHaveLength */13](3)(Jest.ExpectJs[/* expect */0](/* array */[
                                 "a",
                                 "b",
                                 "c"
                               ]));
               }));
         Jest.test("toEqual", (function () {
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], 3, Curry._1(Jest.ExpectJs[/* expect */0], 3));
+                return Jest.ExpectJs[/* toEqual */12](3)(Jest.ExpectJs[/* expect */0](3));
               }));
         Jest.test("toMatch", (function () {
-                return Curry._2(Jest.ExpectJs[/* toMatch */14], "nana", Curry._1(Jest.ExpectJs[/* expect */0], "banana"));
+                return Jest.ExpectJs[/* toMatch */14]("nana")(Jest.ExpectJs[/* expect */0]("banana"));
               }));
         Jest.test("toMatchRe", (function () {
-                return Curry._2(Jest.ExpectJs[/* toMatchRe */15], (/ana/), Curry._1(Jest.ExpectJs[/* expect */0], "banana"));
+                return Jest.ExpectJs[/* toMatchRe */15]((/ana/))(Jest.ExpectJs[/* expect */0]("banana"));
               }));
         Jest.test("toMatchObject", (function () {
-                return Curry._2(Jest.ExpectJs[/* toMatchObject */30], {
-                            a: 1,
-                            b: 2
-                          }, Curry._1(Jest.ExpectJs[/* expect */0], {
+                return Jest.ExpectJs[/* toMatchObject */30]({
+                              a: 1,
+                              b: 2
+                            })(Jest.ExpectJs[/* expect */0]({
                                 a: 1,
                                 b: 2,
                                 c: 3
                               }));
               }));
         Jest.test("toThrow", (function () {
-                return Curry._1(Jest.ExpectJs[/* toThrow */18], Curry._1(Jest.ExpectJs[/* expect */0], (function () {
+                return Jest.ExpectJs[/* toThrow */18](Jest.ExpectJs[/* expect */0]((function () {
                                   throw [
                                         Caml_builtin_exceptions.assert_failure,
                                         [
@@ -245,7 +245,7 @@ describe("ExpectJs", (function () {
                                 })));
               }));
         Jest.test("toThrowMessage", (function () {
-                return Curry._2(Jest.ExpectJs[/* toThrowMessage */20], "Invalid_argument,-3,foo", Curry._1(Jest.ExpectJs[/* expect */0], (function () {
+                return Jest.ExpectJs[/* toThrowMessage */20]("Invalid_argument,-3,foo", Jest.ExpectJs[/* expect */0]((function () {
                                   throw [
                                         Caml_builtin_exceptions.invalid_argument,
                                         "foo"
@@ -253,7 +253,7 @@ describe("ExpectJs", (function () {
                                 })));
               }));
         Jest.test("toThrowMessageRe", (function () {
-                return Curry._2(Jest.ExpectJs[/* toThrowMessageRe */21], (/Assert_failure/), Curry._1(Jest.ExpectJs[/* expect */0], (function () {
+                return Jest.ExpectJs[/* toThrowMessageRe */21]((/Assert_failure/), Jest.ExpectJs[/* expect */0]((function () {
                                   throw [
                                         Caml_builtin_exceptions.assert_failure,
                                         [
@@ -265,7 +265,7 @@ describe("ExpectJs", (function () {
                                 })));
               }));
         return Jest.test("not_ |> toBe", (function () {
-                      return Curry._2(Jest.ExpectJs[/* toBe */2], 4, Curry._1(Jest.ExpectJs[/* not_ */22], Curry._1(Jest.ExpectJs[/* expect */0], 3)));
+                      return Jest.ExpectJs[/* toBe */2](4)(Jest.ExpectJs[/* not_ */22](Jest.ExpectJs[/* expect */0](3)));
                     }));
       }));
 

--- a/lib/js/__tests__/globals_test.js
+++ b/lib/js/__tests__/globals_test.js
@@ -4,15 +4,15 @@ var Jest  = require("../src/jest.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 
 Jest.test("test", (function () {
-        return Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3));
+        return Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3));
       }));
 
 Jest.testAsync("testAsync", (function (done_) {
-        return Curry._1(done_, Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3)));
+        return Curry._1(done_, Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3)));
       }));
 
 Jest.testPromise("testPromise", (function () {
-        return Promise.resolve(Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3)));
+        return Promise.resolve(Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3)));
       }));
 
 Jest.testAll("testAll", /* :: */[
@@ -52,7 +52,7 @@ Jest.testAll("testAll - tuples", /* :: */[
 
 describe("describe", (function () {
         return Jest.test("some aspect", (function () {
-                      return Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3));
+                      return Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3));
                     }));
       }));
 
@@ -63,10 +63,10 @@ describe("beforeAll", (function () {
                 return /* () */0;
               }));
         Jest.test("x is 4", (function () {
-                return Curry._2(Jest.Expect[/* toBe */2], 4, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                return Jest.Expect[/* toBe */2](4)(Jest.Expect[/* expect */0](x[0]));
               }));
         return Jest.test("x is still 4", (function () {
-                      return Curry._2(Jest.Expect[/* toBe */2], 4, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                      return Jest.Expect[/* toBe */2](4)(Jest.Expect[/* expect */0](x[0]));
                     }));
       }));
 
@@ -77,10 +77,10 @@ describe("beforeEach", (function () {
                 return /* () */0;
               }));
         Jest.test("x is 4", (function () {
-                return Curry._2(Jest.Expect[/* toBe */2], 4, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                return Jest.Expect[/* toBe */2](4)(Jest.Expect[/* expect */0](x[0]));
               }));
         return Jest.test("x is suddenly 8", (function () {
-                      return Curry._2(Jest.Expect[/* toBe */2], 8, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                      return Jest.Expect[/* toBe */2](8)(Jest.Expect[/* expect */0](x[0]));
                     }));
       }));
 
@@ -92,12 +92,12 @@ describe("afterAll", (function () {
                         return /* () */0;
                       }));
                 return Jest.test("x is 0", (function () {
-                              return Curry._2(Jest.Expect[/* toBe */2], 0, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                              return Jest.Expect[/* toBe */2](0)(Jest.Expect[/* expect */0](x[0]));
                             }));
               }));
         describe("phase 2", (function () {
                 return Jest.test("x is suddenly 4", (function () {
-                              return Curry._2(Jest.Expect[/* toBe */2], 4, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                              return Jest.Expect[/* toBe */2](4)(Jest.Expect[/* expect */0](x[0]));
                             }));
               }));
         return /* () */0;
@@ -110,10 +110,10 @@ describe("afterEach", (function () {
                 return /* () */0;
               }));
         Jest.test("x is 0", (function () {
-                return Curry._2(Jest.Expect[/* toBe */2], 0, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                return Jest.Expect[/* toBe */2](0)(Jest.Expect[/* expect */0](x[0]));
               }));
         return Jest.test("x is suddenly 4", (function () {
-                      return Curry._2(Jest.Expect[/* toBe */2], 4, Curry._1(Jest.Expect[/* expect */0], x[0]));
+                      return Jest.Expect[/* toBe */2](4)(Jest.Expect[/* expect */0](x[0]));
                     }));
       }));
 
@@ -123,15 +123,15 @@ describe("Only", (function () {
 
 describe("Skip", (function () {
         test.skip("Skip.test", (function () {
-                return Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3));
+                return Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3));
               }));
         test.skip("Skip.testAsync", (function (done_) {
-                return Curry._1(done_, Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3)));
+                return Curry._1(done_, Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3)));
               }));
         test.skip("Skip.testPromise", (function () {
-                return Promise.resolve(Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3)));
+                return Promise.resolve(Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3)));
               }));
-        Jest.Skip[/* testAll */0]("testAll", /* :: */[
+        test.skip("testAll", /* :: */[
               "foo",
               /* :: */[
                 "bar",
@@ -143,7 +143,7 @@ describe("Skip", (function () {
             ], (function (input) {
                 return Jest.Expect[/* toEqual */12](3)(Jest.Expect[/* expect */0](input.length));
               }));
-        Jest.Skip[/* testAll */0]("testAll - tuples", /* :: */[
+        test.skip("testAll - tuples", /* :: */[
               /* tuple */[
                 "foo",
                 3
@@ -166,7 +166,7 @@ describe("Skip", (function () {
               }));
         describe.skip("Skip.describe", (function () {
                 return Jest.test("some aspect", (function () {
-                              return Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3));
+                              return Jest.Expect[/* toBe */2](3)(Jest.Expect[/* expect */0](3));
                             }));
               }));
         return /* () */0;

--- a/lib/js/__tests__/globals_test.js
+++ b/lib/js/__tests__/globals_test.js
@@ -15,6 +15,41 @@ Jest.testPromise("testPromise", (function () {
         return Promise.resolve(Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3)));
       }));
 
+Jest.testAll("testAll", /* :: */[
+      "foo",
+      /* :: */[
+        "bar",
+        /* :: */[
+          "baz",
+          /* [] */0
+        ]
+      ]
+    ], (function (input) {
+        return Jest.Expect[/* toEqual */12](3)(Jest.Expect[/* expect */0](input.length));
+      }));
+
+Jest.testAll("testAll - tuples", /* :: */[
+      /* tuple */[
+        "foo",
+        3
+      ],
+      /* :: */[
+        /* tuple */[
+          "barbaz",
+          6
+        ],
+        /* :: */[
+          /* tuple */[
+            "bananas!",
+            8
+          ],
+          /* [] */0
+        ]
+      ]
+    ], (function (param) {
+        return Jest.Expect[/* toEqual */12](param[1])(Jest.Expect[/* expect */0](param[0].length));
+      }));
+
 describe("describe", (function () {
         return Jest.test("some aspect", (function () {
                       return Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3));
@@ -95,6 +130,39 @@ describe("Skip", (function () {
               }));
         test.skip("Skip.testPromise", (function () {
                 return Promise.resolve(Curry._2(Jest.Expect[/* toBe */2], 3, Curry._1(Jest.Expect[/* expect */0], 3)));
+              }));
+        Jest.Skip[/* testAll */0]("testAll", /* :: */[
+              "foo",
+              /* :: */[
+                "bar",
+                /* :: */[
+                  "baz",
+                  /* [] */0
+                ]
+              ]
+            ], (function (input) {
+                return Jest.Expect[/* toEqual */12](3)(Jest.Expect[/* expect */0](input.length));
+              }));
+        Jest.Skip[/* testAll */0]("testAll - tuples", /* :: */[
+              /* tuple */[
+                "foo",
+                3
+              ],
+              /* :: */[
+                /* tuple */[
+                  "barbaz",
+                  6
+                ],
+                /* :: */[
+                  /* tuple */[
+                    "bananas!",
+                    8
+                  ],
+                  /* [] */0
+                ]
+              ]
+            ], (function (param) {
+                return Jest.Expect[/* toEqual */12](param[1])(Jest.Expect[/* expect */0](param[0].length));
               }));
         describe.skip("Skip.describe", (function () {
                 return Jest.test("some aspect", (function () {

--- a/lib/js/__tests__/jest_test.js
+++ b/lib/js/__tests__/jest_test.js
@@ -13,7 +13,7 @@ describe("Fake Timers", (function () {
                       }), 0);
                 var before = flag[0];
                 jest.runAllTimers();
-                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Curry._1(Jest.Expect[/* expect */0], /* tuple */[
+                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Jest.Expect[/* expect */0](/* tuple */[
                                 before,
                                 flag[0]
                               ]), /* tuple */[
@@ -30,7 +30,7 @@ describe("Fake Timers", (function () {
                       }));
                 var before = flag[0];
                 jest.runAllTicks();
-                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Curry._1(Jest.Expect[/* expect */0], /* tuple */[
+                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Jest.Expect[/* expect */0](/* tuple */[
                                 before,
                                 flag[0]
                               ]), /* tuple */[
@@ -47,7 +47,7 @@ describe("Fake Timers", (function () {
                       }));
                 var before = flag[0];
                 jest.runAllImmediates();
-                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Curry._1(Jest.Expect[/* expect */0], /* tuple */[
+                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Jest.Expect[/* expect */0](/* tuple */[
                                 before,
                                 flag[0]
                               ]), /* tuple */[
@@ -66,7 +66,7 @@ describe("Fake Timers", (function () {
                 jest.runTimersToTime(1000);
                 var inbetween = flag[0];
                 jest.runTimersToTime(1000);
-                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Curry._1(Jest.Expect[/* expect */0], /* tuple */[
+                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Jest.Expect[/* expect */0](/* tuple */[
                                 before,
                                 inbetween,
                                 flag[0]
@@ -89,7 +89,7 @@ describe("Fake Timers", (function () {
                 jest.runOnlyPendingTimers();
                 var inbetween = count[0];
                 jest.runOnlyPendingTimers();
-                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Curry._1(Jest.Expect[/* expect */0], /* tuple */[
+                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Jest.Expect[/* expect */0](/* tuple */[
                                 before,
                                 inbetween,
                                 count[0]
@@ -109,7 +109,7 @@ describe("Fake Timers", (function () {
                 var before = flag[0];
                 jest.clearAllTimers();
                 jest.runAllTimers();
-                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Curry._1(Jest.Expect[/* expect */0], /* tuple */[
+                return Curry._2(Jest.Expect[/* Operators */23][/* = */5], Jest.Expect[/* expect */0](/* tuple */[
                                 before,
                                 flag[0]
                               ]), /* tuple */[

--- a/lib/js/__tests__/mockjs_test.js
+++ b/lib/js/__tests__/mockjs_test.js
@@ -12,46 +12,46 @@ function call(self, arg) {
 describe("inferred_fn", (function () {
         Jest.test("returns undefined", (function () {
                 var mockFn = jest.fn();
-                return Curry._1(Jest.ExpectJs[/* toBeUndefined */28], Curry._1(Jest.ExpectJs[/* expect */0], mockFn.call(/* () */0, /* () */0)));
+                return Jest.ExpectJs[/* toBeUndefined */28](Jest.ExpectJs[/* expect */0](mockFn.call(/* () */0, /* () */0)));
               }));
         Jest.test("black hole for argument type object", (function () {
                 var mockFn = jest.fn();
-                return Curry._1(Jest.ExpectJs[/* toBeUndefined */28], Curry._1(Jest.ExpectJs[/* expect */0], mockFn.call(/* () */0, {
+                return Jest.ExpectJs[/* toBeUndefined */28](Jest.ExpectJs[/* expect */0](mockFn.call(/* () */0, {
                                     property: 42
                                   })));
               }));
         Jest.test("black hole for argument type string", (function () {
                 var mockFn = jest.fn();
-                return Curry._1(Jest.ExpectJs[/* toBeUndefined */28], Curry._1(Jest.ExpectJs[/* expect */0], mockFn.call(/* () */0, "some string")));
+                return Jest.ExpectJs[/* toBeUndefined */28](Jest.ExpectJs[/* expect */0](mockFn.call(/* () */0, "some string")));
               }));
         Jest.test("calls - records call arguments", (function () {
                 var mockFn = jest.fn();
                 mockFn.call(/* () */0, "first");
                 mockFn.call(/* () */0, "second");
-                var calls = Curry._1(Jest.MockJs[/* calls */0], mockFn);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* array */[
-                            "first",
-                            "second"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], calls));
+                var calls = Jest.MockJs[/* calls */0](mockFn);
+                return Jest.ExpectJs[/* toEqual */12](/* array */[
+                              "first",
+                              "second"
+                            ])(Jest.ExpectJs[/* expect */0](calls));
               }));
         Jest.test("mockClear - resets calls", (function () {
                 var mockFn = jest.fn();
-                var before = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var before = Jest.MockJs[/* calls */0](mockFn);
                 /* tuple */[
                   mockFn.call(/* () */0, 1),
                   mockFn.call(/* () */0, 2)
                 ];
-                var inbetween = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var inbetween = Jest.MockJs[/* calls */0](mockFn);
                 mockFn.mockClear();
-                var after = Curry._1(Jest.MockJs[/* calls */0], mockFn);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            /* int array */[],
-                            /* int array */[
-                              1,
-                              2
-                            ],
-                            /* int array */[]
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                var after = Jest.MockJs[/* calls */0](mockFn);
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              /* int array */[],
+                              /* int array */[
+                                1,
+                                2
+                              ],
+                              /* int array */[]
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 inbetween,
                                 after
@@ -59,22 +59,22 @@ describe("inferred_fn", (function () {
               }));
         Jest.test("mockReset - resets calls", (function () {
                 var mockFn = jest.fn();
-                var before = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var before = Jest.MockJs[/* calls */0](mockFn);
                 /* tuple */[
                   mockFn.call(/* () */0, 1),
                   mockFn.call(/* () */0, 2)
                 ];
-                var inbetween = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var inbetween = Jest.MockJs[/* calls */0](mockFn);
                 mockFn.mockReset();
-                var after = Curry._1(Jest.MockJs[/* calls */0], mockFn);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            /* int array */[],
-                            /* int array */[
-                              1,
-                              2
-                            ],
-                            /* int array */[]
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                var after = Jest.MockJs[/* calls */0](mockFn);
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              /* int array */[],
+                              /* int array */[
+                                1,
+                                2
+                              ],
+                              /* int array */[]
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 inbetween,
                                 after
@@ -86,10 +86,10 @@ describe("inferred_fn", (function () {
                 var before = mockFn.call(/* () */0, /* () */0);
                 mockFn.mockReset();
                 var after = mockFn.call(/* () */0, /* () */0);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            128,
-                            undefined
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              128,
+                              undefined
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 after
                               ]));
@@ -98,11 +98,11 @@ describe("inferred_fn", (function () {
                 var mockFn = jest.fn();
                 var before = mockFn.call(/* () */0, 10);
                 mockFn.mockImplementation(Pervasives.string_of_int);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            undefined,
-                            "18",
-                            "24"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              undefined,
+                              "18",
+                              "24"
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 mockFn.call(/* () */0, 18),
                                 mockFn.call(/* () */0, 24)
@@ -115,12 +115,12 @@ describe("inferred_fn", (function () {
                 mockFn.mockImplementationOnce((function (a) {
                         return Pervasives.string_of_int((a << 1));
                       }));
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            undefined,
-                            "18",
-                            "48",
-                            undefined
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              undefined,
+                              "18",
+                              "48",
+                              undefined
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 mockFn.call(/* () */0, 18),
                                 mockFn.call(/* () */0, 24),
@@ -133,11 +133,11 @@ describe("inferred_fn", (function () {
                 var fn = mockFn.bind($$this);
                 var before = fn.call(/* () */0, /* () */0);
                 mockFn.mockReturnThis();
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            undefined,
-                            $$this,
-                            $$this
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              undefined,
+                              $$this,
+                              $$this
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 fn.call(/* () */0, /* () */0),
                                 fn.call(/* () */0, /* () */0)
@@ -147,11 +147,11 @@ describe("inferred_fn", (function () {
                 var mockFn = jest.fn();
                 var before = mockFn.call(/* () */0, 10);
                 mockFn.mockReturnValue(146);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            undefined,
-                            146,
-                            146
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              undefined,
+                              146,
+                              146
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 mockFn.call(/* () */0, 18),
                                 mockFn.call(/* () */0, 24)
@@ -162,12 +162,12 @@ describe("inferred_fn", (function () {
                       var before = mockFn.call(/* () */0, 10);
                       mockFn.mockReturnValueOnce(29);
                       mockFn.mockReturnValueOnce(41);
-                      return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                                  undefined,
-                                  29,
-                                  41,
-                                  undefined
-                                ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                      return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                                    undefined,
+                                    29,
+                                    41,
+                                    undefined
+                                  ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                       before,
                                       mockFn.call(/* () */0, 18),
                                       mockFn.call(/* () */0, 24),
@@ -179,36 +179,36 @@ describe("inferred_fn", (function () {
 describe("fn", (function () {
         Jest.test("calls implementation", (function () {
                 var mockFn = jest.fn(Pervasives.string_of_int);
-                return Curry._2(Jest.ExpectJs[/* toBe */2], "18", Curry._1(Jest.ExpectJs[/* expect */0], Curry._1(mockFn, 18)));
+                return Jest.ExpectJs[/* toBe */2]("18")(Jest.ExpectJs[/* expect */0](Curry._1(mockFn, 18)));
               }));
         Jest.test("calls - records call arguments", (function () {
                 var mockFn = jest.fn(Pervasives.string_of_int);
                 Curry._1(mockFn, 74);
                 Curry._1(mockFn, 89435);
-                var calls = Curry._1(Jest.MockJs[/* calls */0], mockFn);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* int array */[
-                            74,
-                            89435
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], calls));
+                var calls = Jest.MockJs[/* calls */0](mockFn);
+                return Jest.ExpectJs[/* toEqual */12](/* int array */[
+                              74,
+                              89435
+                            ])(Jest.ExpectJs[/* expect */0](calls));
               }));
         test.skip("mockClear - resets calls", (function () {
                 var mockFn = jest.fn(Pervasives.string_of_int);
-                var before = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var before = Jest.MockJs[/* calls */0](mockFn);
                 /* tuple */[
                   Curry._1(mockFn, 1),
                   Curry._1(mockFn, 2)
                 ];
-                var inbetween = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var inbetween = Jest.MockJs[/* calls */0](mockFn);
                 mockFn.mockClear();
-                var after = Curry._1(Jest.MockJs[/* calls */0], mockFn);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            /* int array */[],
-                            /* int array */[
-                              1,
-                              2
-                            ],
-                            /* int array */[]
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                var after = Jest.MockJs[/* calls */0](mockFn);
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              /* int array */[],
+                              /* int array */[
+                                1,
+                                2
+                              ],
+                              /* int array */[]
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 inbetween,
                                 after
@@ -216,22 +216,22 @@ describe("fn", (function () {
               }));
         Jest.test("mockReset - resets calls", (function () {
                 var mockFn = jest.fn(Pervasives.string_of_int);
-                var before = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var before = Jest.MockJs[/* calls */0](mockFn);
                 /* tuple */[
                   Curry._1(mockFn, 1),
                   Curry._1(mockFn, 2)
                 ];
-                var inbetween = Curry._1(Jest.MockJs[/* calls */0], mockFn);
+                var inbetween = Jest.MockJs[/* calls */0](mockFn);
                 mockFn.mockReset();
-                var after = Curry._1(Jest.MockJs[/* calls */0], mockFn);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            /* int array */[],
-                            /* int array */[
-                              1,
-                              2
-                            ],
-                            /* int array */[]
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                var after = Jest.MockJs[/* calls */0](mockFn);
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              /* int array */[],
+                              /* int array */[
+                                1,
+                                2
+                              ],
+                              /* int array */[]
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 inbetween,
                                 after
@@ -243,10 +243,10 @@ describe("fn", (function () {
                 var before = Curry._1(mockFn, 0);
                 mockFn.mockReset();
                 var after = Curry._1(mockFn, 1);
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            "128",
-                            "1"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              "128",
+                              "1"
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 after
                               ]));
@@ -257,11 +257,11 @@ describe("fn", (function () {
                 mockFn.mockImplementation((function (a) {
                         return Pervasives.string_of_int((a << 1));
                       }));
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            "10",
-                            "36",
-                            "48"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              "10",
+                              "36",
+                              "48"
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 Curry._1(mockFn, 18),
                                 Curry._1(mockFn, 24)
@@ -276,12 +276,12 @@ describe("fn", (function () {
                 mockFn.mockImplementationOnce((function (a) {
                         return Pervasives.string_of_int((a << 1));
                       }));
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            "10",
-                            "54",
-                            "48",
-                            "12"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              "10",
+                              "54",
+                              "48",
+                              "12"
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 Curry._1(mockFn, 18),
                                 Curry._1(mockFn, 24),
@@ -292,11 +292,11 @@ describe("fn", (function () {
                 var mockFn = jest.fn(Pervasives.string_of_int);
                 var before = Curry._1(mockFn, 10);
                 mockFn.mockReturnValue("146");
-                return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                            "10",
-                            "146",
-                            "146"
-                          ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                              "10",
+                              "146",
+                              "146"
+                            ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                 before,
                                 Curry._1(mockFn, 18),
                                 Curry._1(mockFn, 24)
@@ -307,12 +307,12 @@ describe("fn", (function () {
                       var before = Curry._1(mockFn, 10);
                       mockFn.mockReturnValueOnce("29");
                       mockFn.mockReturnValueOnce("41");
-                      return Curry._2(Jest.ExpectJs[/* toEqual */12], /* tuple */[
-                                  "10",
-                                  "29",
-                                  "41",
-                                  "12"
-                                ], Curry._1(Jest.ExpectJs[/* expect */0], /* tuple */[
+                      return Jest.ExpectJs[/* toEqual */12](/* tuple */[
+                                    "10",
+                                    "29",
+                                    "41",
+                                    "12"
+                                  ])(Jest.ExpectJs[/* expect */0](/* tuple */[
                                       before,
                                       Curry._1(mockFn, 18),
                                       Curry._1(mockFn, 24),
@@ -326,7 +326,7 @@ describe("fn2", (function () {
                       var mockFn = jest.fn((function (a, b) {
                               return Pervasives.string_of_int(a + b | 0);
                             }));
-                      return Curry._2(Jest.ExpectJs[/* toBe */2], "42", Curry._1(Jest.ExpectJs[/* expect */0], mockFn.call(0, 18, 24)));
+                      return Jest.ExpectJs[/* toBe */2]("42")(Jest.ExpectJs[/* expect */0](mockFn.call(0, 18, 24)));
                     }));
       }));
 

--- a/src/jest.mli
+++ b/src/jest.mli
@@ -9,6 +9,7 @@ module Runner (A : Asserter) : sig
   val test : string -> (unit -> 'a A.t) -> unit
   val testAsync : string -> (('a A.t -> unit) -> unit) -> unit
   val testPromise : string -> (unit -> 'a A.t Js.Promise.t) -> unit
+  val testAll : string -> 'a list -> ('a -> 'b A.t) -> unit
 
   external describe : string -> (unit -> unit) -> unit = "" [@@bs.val]
 
@@ -21,6 +22,7 @@ module Runner (A : Asserter) : sig
     val test : string -> (unit -> 'a A.t) -> unit
     val testAsync : string -> (('a A.t -> unit) -> unit) -> unit
     val testPromise : string -> (unit -> 'a A.t Js.Promise.t) -> unit
+    val testAll : string -> 'a list -> ('a -> 'b A.t) -> unit
     external describe : string -> (unit -> unit) -> unit = "describe.only" [@@bs.val]
   end
 
@@ -28,6 +30,7 @@ module Runner (A : Asserter) : sig
     external test : string -> (unit -> 'a A.t) -> unit = "test.skip" [@@bs.val]
     external testAsync : string -> (('a A.t -> unit) -> unit) -> unit = "test.skip" [@@bs.val]
     external testPromise : string -> (unit -> 'a A.t Js.Promise.t) -> unit = "test.skip" [@@bs.val]
+    val testAll : string -> 'a list -> ('a -> 'b A.t) -> unit
     external describe : string -> (unit -> unit) -> unit = "describe.skip" [@@bs.val]
   end
 end
@@ -35,6 +38,7 @@ end
 val test : string -> (unit -> 'a assertion) -> unit
 val testAsync : string -> (('a assertion -> unit) -> unit) -> unit
 val testPromise : string -> (unit -> 'a assertion Js.Promise.t) -> unit
+val testAll : string -> 'a list -> ('a -> 'b assertion) -> unit
 
 external describe : string -> (unit -> unit) -> unit = "" [@@bs.val]
 
@@ -47,6 +51,7 @@ module Only : sig
   val test : string -> (unit -> 'a assertion) -> unit
   val testAsync : string -> (('a assertion -> unit) -> unit) -> unit
   val testPromise : string -> (unit -> 'a assertion Js.Promise.t) -> unit
+  val testAll : string -> 'a list -> ('a -> 'b assertion) -> unit
   external describe : string -> (unit -> unit) -> unit = "describe.only" [@@bs.val]
 end
 
@@ -54,6 +59,7 @@ module Skip : sig
   external test : string -> (unit -> 'a assertion) -> unit = "test.skip" [@@bs.val]
   external testAsync : string -> (('a assertion -> unit) -> unit) -> unit = "test.skip" [@@bs.val]
   external testPromise : string -> (unit -> 'a assertion Js.Promise.t) -> unit = "test.skip" [@@bs.val]
+  val testAll : string -> 'a list -> ('a -> 'b assertion) -> unit
   external describe : string -> (unit -> unit) -> unit = "describe.skip" [@@bs.val]
 end
 

--- a/src/jest.mli
+++ b/src/jest.mli
@@ -59,7 +59,7 @@ module Skip : sig
   external test : string -> (unit -> 'a assertion) -> unit = "test.skip" [@@bs.val]
   external testAsync : string -> (('a assertion -> unit) -> unit) -> unit = "test.skip" [@@bs.val]
   external testPromise : string -> (unit -> 'a assertion Js.Promise.t) -> unit = "test.skip" [@@bs.val]
-  val testAll : string -> 'a list -> ('a -> 'b assertion) -> unit
+  external testAll : string -> 'a list -> ('a -> 'b assertion) -> unit = "test.skip" [@@bs.val]
   external describe : string -> (unit -> unit) -> unit = "describe.skip" [@@bs.val]
 end
 


### PR DESCRIPTION
Fixes #11 

Went for a `testAll`  function instead of `expectAll`/`expectForEach`/`expectMany`. While this restricts the design possibilities a bit, the major benefit is that it will continue to test the remaining inputs if any of the inputs fail, which is definitely worth it IMO.

cc @frankwallis, would you like to test this out to see how it fits before I merge?